### PR TITLE
Pass -lm at end of linker command line

### DIFF
--- a/build/Linux-386-GCC/Makefile
+++ b/build/Linux-386-GCC/Makefile
@@ -55,7 +55,8 @@ COMPILE_SLOWFLOAT_C = \
   gcc -c -Werror-implicit-function-declaration $(TESTFLOAT_OPTS) \
     $(C_INCLUDES) -O3 -o $@
 MAKELIB = ar crs $@
-LINK = gcc -lm -o $@
+LINK = gcc -o $@
+LIBS = -lm
 
 OBJ = .o
 LIB = .a
@@ -241,7 +242,7 @@ testsoftfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testsoftfloat.c
 
 testsoftfloat$(EXE): $(OBJS_TESTSOFTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TIMESOFTFLOAT = timesoftfloat$(OBJ)
 
@@ -251,7 +252,7 @@ timesoftfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/timesoftfloat.c
 
 timesoftfloat$(EXE): $(OBJS_TIMESOFTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT_GEN = genLoops$(OBJ) testfloat_gen$(OBJ)
 
@@ -267,7 +268,7 @@ testfloat_gen$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat_gen.c
 
 testfloat_gen$(EXE): $(OBJS_TESTFLOAT_GEN) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT_VER = verLoops$(OBJ) testfloat_ver$(OBJ)
 
@@ -284,7 +285,7 @@ testfloat_ver$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat_ver.c
 
 testfloat_ver$(EXE): $(OBJS_TESTFLOAT_VER) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT = subjfloat$(OBJ) subjfloat_functions$(OBJ) testfloat$(OBJ)
 
@@ -304,7 +305,7 @@ testfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat.c
 
 testfloat$(EXE): $(OBJS_TESTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 .PHONY: clean
 clean:

--- a/build/Linux-386-SSE2-GCC/Makefile
+++ b/build/Linux-386-SSE2-GCC/Makefile
@@ -55,7 +55,8 @@ COMPILE_SLOWFLOAT_C = \
   gcc -c -Werror-implicit-function-declaration $(TESTFLOAT_OPTS) \
     $(C_INCLUDES) -O3 -o $@
 MAKELIB = ar crs $@
-LINK = gcc -lm -o $@
+LINK = gcc -o $@
+LIBS = -lm
 
 OBJ = .o
 LIB = .a
@@ -241,7 +242,7 @@ testsoftfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testsoftfloat.c
 
 testsoftfloat$(EXE): $(OBJS_TESTSOFTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TIMESOFTFLOAT = timesoftfloat$(OBJ)
 
@@ -251,7 +252,7 @@ timesoftfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/timesoftfloat.c
 
 timesoftfloat$(EXE): $(OBJS_TIMESOFTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT_GEN = genLoops$(OBJ) testfloat_gen$(OBJ)
 
@@ -267,7 +268,7 @@ testfloat_gen$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat_gen.c
 
 testfloat_gen$(EXE): $(OBJS_TESTFLOAT_GEN) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT_VER = verLoops$(OBJ) testfloat_ver$(OBJ)
 
@@ -284,7 +285,7 @@ testfloat_ver$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat_ver.c
 
 testfloat_ver$(EXE): $(OBJS_TESTFLOAT_VER) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT = subjfloat$(OBJ) subjfloat_functions$(OBJ) testfloat$(OBJ)
 
@@ -304,7 +305,7 @@ testfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat.c
 
 testfloat$(EXE): $(OBJS_TESTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 .PHONY: clean
 clean:

--- a/build/Linux-x86_64-GCC/Makefile
+++ b/build/Linux-x86_64-GCC/Makefile
@@ -56,6 +56,7 @@ COMPILE_SLOWFLOAT_C = \
     $(C_INCLUDES) -O3 -o $@
 MAKELIB = ar crs $@
 LINK = gcc -lm -o $@
+LIBS = -lm
 
 OBJ = .o
 LIB = .a
@@ -241,7 +242,7 @@ testsoftfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testsoftfloat.c
 
 testsoftfloat$(EXE): $(OBJS_TESTSOFTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TIMESOFTFLOAT = timesoftfloat$(OBJ)
 
@@ -251,7 +252,7 @@ timesoftfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/timesoftfloat.c
 
 timesoftfloat$(EXE): $(OBJS_TIMESOFTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT_GEN = genLoops$(OBJ) testfloat_gen$(OBJ)
 
@@ -267,7 +268,7 @@ testfloat_gen$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat_gen.c
 
 testfloat_gen$(EXE): $(OBJS_TESTFLOAT_GEN) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT_VER = verLoops$(OBJ) testfloat_ver$(OBJ)
 
@@ -284,7 +285,7 @@ testfloat_ver$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat_ver.c
 
 testfloat_ver$(EXE): $(OBJS_TESTFLOAT_VER) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 OBJS_TESTFLOAT = subjfloat$(OBJ) subjfloat_functions$(OBJ) testfloat$(OBJ)
 
@@ -304,7 +305,7 @@ testfloat$(OBJ): \
 	$(COMPILE_C) $(SOURCE_DIR)/testfloat.c
 
 testfloat$(EXE): $(OBJS_TESTFLOAT) testfloat$(LIB) $(SOFTFLOAT_LIB)
-	$(LINK) $^
+	$(LINK) $^ $(LIBS)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
The order of arguments to the gcc matters, and putting -lm at the
beginning doesn't expose libm to subsequenly listedt object files.