### PR TITLE
Support testing f32_sqrt

### DIFF
--- a/source/subj-C/subjfloat.c
+++ b/source/subj-C/subjfloat.c
@@ -212,6 +212,16 @@ float32_t subj_f32_div( float32_t a, float32_t b )
 
 }
 
+float32_t subj_f32_sqrt( float32_t a )
+{
+    union f32_f uA, uZ;
+
+    uA.f32 = a;
+    uZ.f = sqrtf( uA.f );
+    return uZ.f32;
+
+}
+
 bool subj_f32_eq( float32_t a, float32_t b )
 {
     union f32_f uA, uB;

--- a/source/subj-C/subjfloat.c
+++ b/source/subj-C/subjfloat.c
@@ -252,6 +252,18 @@ bool subj_f32_lt( float32_t a, float32_t b )
 
 }
 
+float32_t subj_f32_mulAdd( float32_t a, float32_t b, float32_t c )
+{
+    union f32_f uA, uB, uC, uZ;
+
+    uA.f32 = a;
+    uB.f32 = b;
+    uC.f32 = b=c;
+    uZ.f = fmaf( uA.f, uB.f, uC.f );
+    return uZ.f32;
+
+}
+
 /*----------------------------------------------------------------------------
 *----------------------------------------------------------------------------*/
 
@@ -434,6 +446,18 @@ bool subj_f64_lt( float64_t a, float64_t b )
     uA.f64 = a;
     uB.f64 = b;
     return (uA.d < uB.d);
+
+}
+
+float64_t subj_f64_mulAdd( float64_t a, float64_t b, float64_t c )
+{
+    union f64_d uA, uB, uC, uZ;
+
+    uA.f64 = a;
+    uB.f64 = b;
+    uC.f64 = c;
+    uZ.d = fma( uA.d, uB.d, uC.d );
+    return uZ.f64;
 
 }
 

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -17,6 +17,7 @@
 #define SUBJ_F32_SUB
 #define SUBJ_F32_MUL
 #define SUBJ_F32_DIV
+#define SUBJ_F32_SQRT
 #define SUBJ_F32_EQ
 #define SUBJ_F32_LE
 #define SUBJ_F32_LT

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -22,6 +22,8 @@
 #define SUBJ_F32_LE
 #define SUBJ_F32_LT
 
+#define SUBJ_F32_MULADD
+
 #ifdef FLOAT64
 
 #define SUBJ_UI32_TO_F64
@@ -44,6 +46,8 @@
 #define SUBJ_F64_EQ
 #define SUBJ_F64_LE
 #define SUBJ_F64_LT
+
+#define SUBJ_F64_MULADD
 
 #endif
 


### PR DESCRIPTION
This commit adds a ```subj_f32_sqrt``` routine and defines the ```SUBJ_F32_SQRT``` macro, so that ```f32_sqrt``` may be tested.