### PR TITLE
add typedef for function and roundingMode enumeration

### DIFF
--- a/source/functions.h
+++ b/source/functions.h
@@ -40,7 +40,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 /*----------------------------------------------------------------------------
 | Warning:  This list must match the contents of "functionInfos.c".
 *----------------------------------------------------------------------------*/
-enum {
+typedef enum {
     /*------------------------------------------------------------------------
     *------------------------------------------------------------------------*/
 #ifdef FLOAT16
@@ -277,9 +277,9 @@ enum {
     F128_LT_QUIET,
 #endif
     NUM_FUNCTIONS
-};
+} function_t;
 
-enum {
+typedef enum {
     ROUND_NEAR_EVEN = 1,
     ROUND_MINMAG,
     ROUND_MIN,
@@ -289,7 +289,7 @@ enum {
     ROUND_ODD,
 #endif
     NUM_ROUNDINGMODES
-};
+} roundingMode_t;
 enum {
     TININESS_BEFORE_ROUNDING = 1,
     TININESS_AFTER_ROUNDING,

--- a/source/functions.h
+++ b/source/functions.h
@@ -277,7 +277,7 @@ typedef enum {
     F128_LT_QUIET,
 #endif
     NUM_FUNCTIONS
-} function_t;
+} testfloat_function_t;
 
 typedef enum {
     ROUND_NEAR_EVEN = 1,


### PR DESCRIPTION
This patch adds typedef for fuctions and rounding mode enumeration.

In https://github.com/sequencer/arithmetic/blob/2685fb7ec6dc7cca7ee3808377d841d19a9d2ced/emulator/src/testharness.h#L32 and https://github.com/sequencer/arithmetic/blob/2685fb7ec6dc7cca7ee3808377d841d19a9d2ced/emulator/src/testharness.cc#L107 , I am trying to use softfloat and testfloat as link libraries to test my float-point unit and found it was necessary to have the enumeration type definition for exporting the 'function' method. Besides, I also mentioned this in https://github.com/ucb-bar/berkeley-softfloat-3/pull/22.