### PR TITLE
[FLOAT16] Extending minimal support for testfloat f16 testing to multiple f16 operations

### DIFF
--- a/source/subj-C/subjfloat.c
+++ b/source/subj-C/subjfloat.c
@@ -856,11 +856,11 @@ bool subj_f128M_lt( const float128_t *aPtr, const float128_t *bPtr )
 
 #if defined(FLOAT16) && defined(FLT16_MIN)
 
-union f16_f { float16_t f16; _Float16 h; };
+union f16_h { float16_t f16; _Float16 h; };
 
 float16_t subj_f16_add( float16_t a, float16_t b )
 {
-    union f16_f uA, uB, uZ;
+    union f16_h uA, uB, uZ;
 
     uA.f16 = a;
     uB.f16 = b;
@@ -871,7 +871,7 @@ float16_t subj_f16_add( float16_t a, float16_t b )
 
 float16_t subj_f16_sub( float16_t a, float16_t b )
 {
-    union f16_f uA, uB, uZ;
+    union f16_h uA, uB, uZ;
 
     uA.f16 = a;
     uB.f16 = b;
@@ -882,7 +882,7 @@ float16_t subj_f16_sub( float16_t a, float16_t b )
 
 float16_t subj_f16_mul( float16_t a, float16_t b )
 {
-    union f16_f uA, uB, uZ;
+    union f16_h uA, uB, uZ;
 
     uA.f16 = a;
     uB.f16 = b;
@@ -893,7 +893,7 @@ float16_t subj_f16_mul( float16_t a, float16_t b )
 
 float16_t subj_f16_div( float16_t a, float16_t b )
 {
-    union f16_f uA, uB, uZ;
+    union f16_h uA, uB, uZ;
 
     uA.f16 = a;
     uB.f16 = b;
@@ -904,7 +904,7 @@ float16_t subj_f16_div( float16_t a, float16_t b )
 
 float32_t subj_f16_to_f32( float16_t a )
 {
-    union f16_f uA;
+    union f16_h uA;
     union f32_f uZ;
 
     uA.f16 = a;
@@ -916,7 +916,7 @@ float32_t subj_f16_to_f32( float16_t a )
 float16_t subj_f32_to_f16( float32_t a )
 {
     union f32_f uA;
-    union f16_f uZ;
+    union f16_h uZ;
 
     uA.f32 = a;
     uZ.h = uA.f;
@@ -924,6 +924,66 @@ float16_t subj_f32_to_f16( float32_t a )
 
 }   
 
+float16_t subj_f64_to_f16( float64_t a )
+{
+    union f64_d uA;
+    union f16_h uZ;
+
+    uA.f64 = a;
+    uZ.h = uA.d;
+    return uZ.f16;
+
+}   
+
+float64_t subj_f16_to_f64( float16_t a )
+{
+    union f16_h uA;
+    union f64_d uZ;
+
+    uA.f16 = a;
+    uZ.d = uA.h;
+    return uZ.f64;
+
+}
+
+uint_fast32_t subj_f16_to_ui32_rx_minMag( float16_t a )
+{
+    union f16_h uA;
+
+    uA.f16 = a;
+    return (uint32_t) uA.h;
+
+}
+
+bool subj_f16_eq( float16_t a, float16_t b )
+{
+    union f16_h uA, uB;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    return (uA.h == uB.h);
+
+}
+
+bool subj_f16_le( float16_t a, float16_t b )
+{
+    union f16_h uA, uB;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    return (uA.h <= uB.h);
+
+}
+
+bool subj_f16_lt( float16_t a, float16_t b )
+{
+    union f16_h uA, uB;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    return (uA.h < uB.h);
+
+}
 
 #endif // defined(FLOAT16) && defined(FLT16_MIN)
 

--- a/source/subj-C/subjfloat.c
+++ b/source/subj-C/subjfloat.c
@@ -854,3 +854,53 @@ bool subj_f128M_lt( const float128_t *aPtr, const float128_t *bPtr )
 
 #endif
 
+#ifdef FLOAT16
+
+union f16_f { float16_t f16; __fp16 h; };
+
+float16_t subj_f16_add( float16_t a, float16_t b )
+{
+    union f16_f uA, uB, uZ;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    uZ.h = uA.h + uB.h;
+    return uZ.f16;
+
+}
+
+float16_t subj_f16_sub( float16_t a, float16_t b )
+{
+    union f16_f uA, uB, uZ;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    uZ.h = uA.h - uB.h;
+    return uZ.f16;
+
+}
+
+float16_t subj_f16_mul( float16_t a, float16_t b )
+{
+    union f16_f uA, uB, uZ;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    uZ.h = uA.h * uB.h;
+    return uZ.f16;
+
+}
+
+float16_t subj_f16_div( float16_t a, float16_t b )
+{
+    union f16_f uA, uB, uZ;
+
+    uA.f16 = a;
+    uB.f16 = b;
+    uZ.h = uA.h / uB.h;
+    return uZ.f16;
+
+}
+
+#endif
+

--- a/source/subj-C/subjfloat.c
+++ b/source/subj-C/subjfloat.c
@@ -854,9 +854,9 @@ bool subj_f128M_lt( const float128_t *aPtr, const float128_t *bPtr )
 
 #endif
 
-#ifdef FLOAT16
+#if defined(FLOAT16) && defined(FLT16_MIN)
 
-union f16_f { float16_t f16; __fp16 h; };
+union f16_f { float16_t f16; _Float16 h; };
 
 float16_t subj_f16_add( float16_t a, float16_t b )
 {
@@ -902,5 +902,5 @@ float16_t subj_f16_div( float16_t a, float16_t b )
 
 }
 
-#endif
+#endif // defined(FLOAT16) && defined(FLT16_MIN)
 

--- a/source/subj-C/subjfloat.c
+++ b/source/subj-C/subjfloat.c
@@ -902,5 +902,28 @@ float16_t subj_f16_div( float16_t a, float16_t b )
 
 }
 
+float32_t subj_f16_to_f32( float16_t a )
+{
+    union f16_f uA;
+    union f32_f uZ;
+
+    uA.f16 = a;
+    uZ.f = uA.h;
+    return uZ.f32;
+
+}   
+
+float16_t subj_f32_to_f16( float32_t a )
+{
+    union f32_f uA;
+    union f16_f uZ;
+
+    uA.f32 = a;
+    uZ.h = uA.f;
+    return uZ.f16;
+
+}   
+
+
 #endif // defined(FLOAT16) && defined(FLT16_MIN)
 

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -13,6 +13,8 @@
 #define SUBJ_F16_SUB
 #define SUBJ_F16_MUL
 #define SUBJ_F16_DIV
+#define SUBJ_F16_TO_F32
+#define SUBJ_F32_TO_F16
 
 #endif // defined(FLOAT16) && defined(FLT16_MIN)
 

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -15,6 +15,12 @@
 #define SUBJ_F16_DIV
 #define SUBJ_F16_TO_F32
 #define SUBJ_F32_TO_F16
+#define SUBJ_F64_TO_F16
+#define SUBJ_F16_TO_F64
+
+#define SUBJ_F16_EQ
+#define SUBJ_F16_LE
+#define SUBJ_F16_LT
 
 #endif // defined(FLOAT16) && defined(FLT16_MIN)
 

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -1,3 +1,4 @@
+
 // Trying to get half precision (binary16) support if available
 #define __STDC_WANT_IEC_60559_TYPES_EXT__
 #include <float.h>

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -131,3 +131,10 @@
 
 #endif
 
+#if defined FLOAT16
+#define SUBJ_F16_ADD
+#define SUBJ_F16_SUB
+#define SUBJ_F16_MUL
+#define SUBJ_F16_DIV
+#endif
+

--- a/source/subj-C/subjfloat_config.h
+++ b/source/subj-C/subjfloat_config.h
@@ -1,8 +1,19 @@
-
+// Trying to get half precision (binary16) support if available
+#define __STDC_WANT_IEC_60559_TYPES_EXT__
+#include <float.h>
 /*----------------------------------------------------------------------------
 | The following macros are defined to indicate all the subject functions that
 | exist.
 *----------------------------------------------------------------------------*/
+
+#if defined(FLOAT16) && defined(FLT16_MIN)
+
+#define SUBJ_F16_ADD
+#define SUBJ_F16_SUB
+#define SUBJ_F16_MUL
+#define SUBJ_F16_DIV
+
+#endif // defined(FLOAT16) && defined(FLT16_MIN)
 
 #define SUBJ_UI32_TO_F32
 #define SUBJ_UI64_TO_F32
@@ -129,12 +140,5 @@
 #define SUBJ_F128_LE
 #define SUBJ_F128_LT
 
-#endif
-
-#if defined FLOAT16
-#define SUBJ_F16_ADD
-#define SUBJ_F16_SUB
-#define SUBJ_F16_MUL
-#define SUBJ_F16_DIV
 #endif
 


### PR DESCRIPTION
It looks like FLOAT16 was only partially available in testfloat and that generic mapping for `subj_f16_add`, `subj_f16_sub`, `subj_f16_mul`, and `subj_f16_div` were not yet available.

This patch adds such support, for now conditioned on `FLOAT16` macro. This may need to be revisited as I am not sure the `FLOAT16` macro was meant to indicate arithmetic support for half precision.

Support for the following operation is introduced: `f16_add`, `f16_sub`, `f16_mul`, `f16_div`, `f16_to_f32`, `f32_to_f16`, `f16_to_f64`, `f64_to_f16`, `f16_eq`, `f16_lt`, `f16_le`.

As half-precision arithmetic support is becoming more and more pervasive (e.g. RISC-V Zfh scalar extension or vector Zvfh extension, ARM scalar and vector support in v8 as well), it seems natural to extend testfloat to support this format fully.


⚠️ `f16_to_f32` and `f32_to_f16` require https://github.com/ucb-bar/berkeley-testfloat-3/pull/19 (their entries appear after BFloat16 conversions in the array `subjfloat_functions` and `standardFunctionInfos` and so they are susceptible to the bug addressed in the PR).

## How this was tested

After building softfloat and testfloat on a Mac with Apple Silicon (AArch64):

```
for op in f16_add f16_sub f16_mul f16_div f16_to_f32 f32_to_f16 f16_to_f64 f64_to_f16 f16_eq f16_le f16_lt; do ./testfloat $op -level2; done
Testing f16_add, rounding near_even.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_add, rounding near_even.
Testing f16_add, rounding minMag.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_add, rounding minMag.
Testing f16_add, rounding min.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_add, rounding min.
Testing f16_add, rounding max.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_add, rounding max.
Testing f16_sub, rounding near_even.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_sub, rounding near_even.
Testing f16_sub, rounding minMag.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_sub, rounding minMag.
Testing f16_sub, rounding min.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_sub, rounding min.
Testing f16_sub, rounding max.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_sub, rounding max.
Testing f16_mul, rounding near_even.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_mul, rounding near_even.
Testing f16_mul, rounding minMag.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_mul, rounding minMag.
Testing f16_mul, rounding min.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_mul, rounding min.
Testing f16_mul, rounding max.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_mul, rounding max.
Testing f16_div, rounding near_even.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_div, rounding near_even.
Testing f16_div, rounding minMag.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_div, rounding minMag.
Testing f16_div, rounding min.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_div, rounding min.
Testing f16_div, rounding max.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_div, rounding max.
Testing f16_to_f32.
2448 tests total.
2448 tests performed.
In 2448 tests, no errors found in f16_to_f32.
Testing f32_to_f16, rounding near_even.
8800 tests total.
8800 tests performed.
In 8800 tests, no errors found in f32_to_f16, rounding near_even.
Testing f32_to_f16, rounding minMag.
8800 tests total.
8800 tests performed.
In 8800 tests, no errors found in f32_to_f16, rounding minMag.
Testing f32_to_f16, rounding min.
8800 tests total.
8800 tests performed.
In 8800 tests, no errors found in f32_to_f16, rounding min.
Testing f32_to_f16, rounding max.
8800 tests total.
8800 tests performed.
In 8800 tests, no errors found in f32_to_f16, rounding max.
Testing f16_to_f64.
2448 tests total.
2448 tests performed.
In 2448 tests, no errors found in f16_to_f64.
Testing f64_to_f16, rounding near_even.
26112 tests total.
26112 tests performed.
In 26112 tests, no errors found in f64_to_f16, rounding near_even.
Testing f64_to_f16, rounding minMag.
26112 tests total.
26112 tests performed.
In 26112 tests, no errors found in f64_to_f16, rounding minMag.
Testing f64_to_f16, rounding min.
26112 tests total.
26112 tests performed.
In 26112 tests, no errors found in f64_to_f16, rounding min.
Testing f64_to_f16, rounding max.
26112 tests total.
26112 tests performed.
In 26112 tests, no errors found in f64_to_f16, rounding max.
Testing f16_eq.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_eq.
Testing f16_le.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_le.
Testing f16_lt.
1254528 tests total.
1254528 tests performed.
In 1254528 tests, no errors found in f16_lt.
```

 